### PR TITLE
Add docs/bonsai-docfx submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/bonsai-docfx"]
+	path = docs/bonsai-docfx
+	url = https://github.com/bonsai-rx/docfx-tools


### PR DESCRIPTION
Adds the `docs/bonsai-docfx` git submodule pointing to [`bonsai-rx/docfx-tools`](https://github.com/bonsai-rx/docfx-tools) at revision `d33401b473d647237d88b3eaa73b0dae3fc08ea7` (the revision expected by prefect's `SubmoduleValidationRule`).

The submodule provides the docfx template and tooling referenced by `docs/docfx.json`.

Closes #15
