### PR TITLE
Update package dependency versions

### DIFF
--- a/src/BonZeb.Design/BonZeb.Design.csproj
+++ b/src/BonZeb.Design/BonZeb.Design.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.5.0" />
-    <PackageReference Include="Bonsai.System" Version="2.5.1" />
-    <PackageReference Include="Bonsai.Vision" Version="2.5.1" />
-    <PackageReference Include="Bonsai.Vision.Design" Version="2.5.1" />
-    <PackageReference Include="OpenCV.Net" Version="3.3.1" />
+    <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.System" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Vision" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Vision.Design" Version="2.9.0" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
     <PackageReference Include="OpenTK" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/BonZeb/BonZeb.csproj
+++ b/src/BonZeb/BonZeb.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.5.0" />
-    <PackageReference Include="Bonsai.Vision" Version="2.5.1" />
-    <PackageReference Include="MathNet.Numerics" Version="4.5.1" />
-    <PackageReference Include="OpenCV.Net" Version="3.3.1" />
+    <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Vision" Version="2.9.0" />
+    <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
+    <PackageReference Include="OpenCV.Net" Version="3.4.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps the package dependency versions in both `src/BonZeb/BonZeb.csproj` and `src/BonZeb.Design/BonZeb.Design.csproj`:

| Package | Old | New |
|---|---|---|
| Bonsai.Core, Bonsai.System, Bonsai.Vision, Bonsai.Vision.Design | 2.5.x | 2.9.0 |
| OpenCV.Net | 3.3.1 | 3.4.2 |
| MathNet.Numerics | 4.5.1 | 4.15.0 |
| OpenTK | 3.1.0 | 3.1.0 (unchanged) |

OpenTK stays on 3.x since Bonsai's ecosystem (Bonsai.Shaders etc.) hasn't changed.

Closes https://github.com/ncguilbeault/BonZeb/issues/14
